### PR TITLE
fixed scrolling behavior default menu 1047

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -398,3 +398,7 @@ html.no-history .fl-viewport-header .nav-left {
 .hamburger-inner::after {
   background-color: #333333;
 }
+
+.has-overlay-menu {
+  overflow-y: hidden;
+}

--- a/js/menu.js
+++ b/js/menu.js
@@ -34,6 +34,7 @@ function init() {
   $('.fl-menu-overlay').click(function() {
     $(this).closest('.fl-menu').removeClass('active');
     $('.fl-viewport-header .hamburger').removeClass('is-active');
+    $('body').removeClass('has-overlay-menu');
   });
 
   $('[open-about-overlay]').on('click', function() {
@@ -45,5 +46,6 @@ function init() {
   $('[data-fl-toggle-menu]').click(function (event) {
     event.preventDefault();
     $('.fl-viewport-header .hamburger').toggleClass('is-active');
+    $('body').toggleClass('has-overlay-menu');
   });
 }


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/1047
## Description
Changed scroll behavior to prevent scrolling background.
## Screenshots/screencasts
![default-menu](https://user-images.githubusercontent.com/52824216/64010707-fb7b5000-cb22-11e9-9ae6-60297b662947.gif)
## Backward compatibility
This change is fully backward compatible.