### PR TITLE
Fixes drop area

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -21,7 +21,7 @@ html.android .fl-with-top-menu main.fl-page-content-wrapper {
   min-height: calc(100vh - 44px);
 }
 
-html.web[data-has-notch].supports-container .fl-with-top-menu {
+[data-has-notch].supports-container .fl-with-top-menu {
   padding-bottom: 0;
 }
 

--- a/css/menu.css
+++ b/css/menu.css
@@ -21,6 +21,10 @@ html.android .fl-with-top-menu main.fl-page-content-wrapper {
   min-height: calc(100vh - 44px);
 }
 
+html.web[data-has-notch].supports-container .fl-with-top-menu {
+  padding-bottom: 0;
+}
+
 .fl-viewport-header {
   height: 44px;
   margin: 0 auto;

--- a/css/menu.css
+++ b/css/menu.css
@@ -15,6 +15,12 @@
   padding-top: 44px;
 }
 
+html.web .fl-with-top-menu main.fl-page-content-wrapper,
+html.android .fl-with-top-menu main.fl-page-content-wrapper {
+  /* Remove the height of the menu */
+  min-height: calc(100vh - 44px);
+}
+
 .fl-viewport-header {
   height: 44px;
   margin: 0 auto;


### PR DESCRIPTION
- We remove `body`'s bottom padding on `[data-has-notch]` devices in Edit, for apps with container support
- We remove the menu height from the drop area height when using `100vh` [web , android]