### PR TITLE
Fixes issue where menu was disappearing when saving changes

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -36,9 +36,11 @@ Fliplet.Widget.onSaveRequest(function() {
     hide: hide
   }).then(function() {
     Fliplet.Widget.complete();
+    Fliplet.Studio.emit('reload-page-preview');
   });
 });
 
 Fliplet.Widget.onCancelRequest(function() {
   Fliplet.Widget.complete();
+  Fliplet.Studio.emit('reload-page-preview');
 });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4941

## Description
Added Fliplet.Studio.emit('reload-page-preview') after save or cancel request.

## Screenshots/screencasts
![menu demo](https://user-images.githubusercontent.com/52824207/70391907-ccf2f800-19e2-11ea-88e0-a1d0a0e04d4f.gif)

## Backward compatibility
This change is fully backward compatible.