### PR TITLE
Menu is not disappearing after save or cancel event

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -40,6 +40,8 @@ Fliplet.Widget.onSaveRequest(function() {
   });
 });
 
+Fliplet.Widget.toggleCancelButton(false);
+
 Fliplet.Widget.onCancelRequest(function() {
   Fliplet.Widget.complete();
   Fliplet.Studio.emit('reload-page-preview');


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#4941

## Description
Added reload event on save and cancel events. Strangely these events were not working last time I tried to fix this issue.

## Backward compatibility
This change is fully backward compatible.