### PR TITLE
Users will see correct exit button icon

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -13,7 +13,7 @@ function init() {
     var $exitButton = $([
       '<li class="linked with-icon" data-fl-exit-app>',
         '<div class="fl-menu-icon">',
-          '<i class="fa fa-sign-out"></i>',
+          '<i class="fa fa-fw fa-sign-out"></i>',
         '</div>',
         '<i class="fa fa-angle-right linked-icon" aria-hidden="true"></i>',
         '<span class="internal-link buttonControl">Exit</span>',

--- a/js/menu.js
+++ b/js/menu.js
@@ -9,6 +9,27 @@ function init() {
   var data = Fliplet.Widget.getData(menuInstanceId) || {};
   var lastScrollTop = 0;
 
+  Fliplet.Hooks.on('addExitAppMenuLink', function () {
+    var $exitButton = $([
+      '<li class="linked with-icon" data-fl-exit-app>',
+        '<div class="fl-menu-icon">',
+          '<i class="fa fa-sign-out"></i>',
+        '</div>',
+        '<i class="fa fa-angle-right linked-icon" aria-hidden="true"></i>',
+        '<span class="internal-link buttonControl">Exit</span>',
+      '</li>'
+    ].join(''));
+
+    $exitButton.on('click', function onExitClick() {
+      Fliplet.Navigate.exitApp();
+    });
+
+    $menuElement.find('ul').append($exitButton);
+
+    // Prevent default "Exit" link from being added
+    return Promise.reject();
+  });
+
   if ($('li.with-icon').length) {
     $('.main-menu').addClass('with-icons');
   }


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4333

## Description
Users will see the correct exit button icon

## Screenshots/screencasts
![screenshot-2020-03-24_14 59 46 248](https://user-images.githubusercontent.com/53430352/77433067-900f0d80-6de7-11ea-917a-6a2cdb3f1d25.png)

## Backward compatibility

This change is fully backward compatible.