### PR TITLE
PS-1810: Deduplicate menu pages on render (#35)

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -9,6 +9,30 @@ function init() {
   var data = Fliplet.Widget.getData(menuInstanceId) || {};
   var lastScrollTop = 0;
 
+  // Remove stale master page references that should have been replaced by production pages
+  var appPages = Fliplet.Env.get('appPages') || [];
+  var masterPageIds = {};
+
+  appPages.forEach(function(p) {
+    if (p.masterPageId) {
+      masterPageIds[p.masterPageId] = true;
+    }
+  });
+
+  if (data.pages) {
+    data.pages = data.pages.filter(function(page) {
+      return !page.pageId || !masterPageIds[page.pageId];
+    });
+  }
+
+  $menuElement.find('li[data-page-id]').each(function() {
+    var pageId = $(this).attr('data-page-id');
+
+    if (pageId && masterPageIds[pageId]) {
+      $(this).remove();
+    }
+  });
+
   Fliplet.Hooks.on('addExitAppMenuLink', function () {
     var $exitButton = $([
       '<li class="linked with-icon" data-fl-exit-app>',

--- a/js/menu.js
+++ b/js/menu.js
@@ -21,16 +21,18 @@ function init() {
 
   if (data.pages) {
     data.pages = data.pages.filter(function(page) {
-      return !page.pageId || !masterPageIds[page.pageId];
+      return !(page.pageId && masterPageIds[page.pageId]);
     });
   }
 
-  $menuElement.find('li[data-page-id]').each(function() {
-    var pageId = $(this).attr('data-page-id');
+  Fliplet().then(function() {
+    $menuElement.find('li[data-page-id]').each(function() {
+      var pageId = $(this).attr('data-page-id');
 
-    if (pageId && masterPageIds[pageId]) {
-      $(this).remove();
-    }
+      if (pageId && masterPageIds[pageId]) {
+        $(this).remove();
+      }
+    });
   });
 
   Fliplet.Hooks.on('addExitAppMenuLink', function () {


### PR DESCRIPTION
* Deduplicate data.pages to fix corrupted menu data rendering

Filter duplicate pages by pageId after getData() to prevent duplicated menu items from displaying in the UI.

Ref: PS-1810



* Filter stale master pages and remove duplicated DOM elements

Use Fliplet.Env.get('appPages') masterPageId mapping to filter data.pages and remove already-rendered li elements from build.html.



---------